### PR TITLE
Sign kairos-agent and change release artifact

### DIFF
--- a/.github/workflows/release_bin.yaml
+++ b/.github/workflows/release_bin.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # undocumented OIDC support.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,6 +20,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@v2
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # Make sure to check the documentation at http://goreleaser.com
+project_name: kairos-agent
 builds:
   - ldflags:
       - -w -s
@@ -11,14 +12,14 @@ builds:
       - arm64
       - 386
     main: ./cmd/agent/
-    id: "kairos-agent"
-    binary: "kairos-agent"
+    binary: '{{ .ProjectName }}'
 source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{ .Tag }}-source'
 archives:
   # Default template uses underscores instead of -
   - name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    # TODO: this is deprecated -> https://goreleaser.com/deprecations#archivesreplacements
     replacements:
       darwin: Darwin
       linux: Linux
@@ -29,6 +30,14 @@ checksum:
   name_template: '{{ .ProjectName }}-{{ .Tag }}-checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-next"
+signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
+    artifacts: all
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
This patch changes the release artifact to be named kairos-agent instead
of just kairos, so its clear what the archive is referring to.

Also adds keyless signing of the generated artifacts and provides both
key/cert of ALL artifacts to validate the signature

Signed-off-by: Itxaka <itxaka@spectrocloud.com><!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
